### PR TITLE
🚧 Fix install as dependency on npm3

### DIFF
--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -236,7 +236,7 @@ function installModules(installedModules, moduleInfos, index) {
     });
 }
 
-function linkFromParentIfNecessary() {
+function prepareInstallAsDependency() {
   if (!installedAsDependency) {
     return Promise.resolve();
   }
@@ -244,7 +244,7 @@ function linkFromParentIfNecessary() {
   return systools.link(path.join(process.cwd(), '..'), path.join(process.cwd(), 'node_modules'));
 }
 
-function removeParentLinkIfNecessary() {
+function cleanupInstallAsDependency() {
   if (!installedAsDependency) {
     return Promise.resolve();
   }
@@ -271,7 +271,7 @@ function run() {
   let moduleInfos;
   checkStartConditions()
     .then(() => {
-      return linkFromParentIfNecessary();
+      return prepareInstallAsDependency();
     })
     .then(() => {
       return Promise.all([
@@ -299,7 +299,7 @@ function run() {
       return installModules(installedModules, moduleInfos);
     })
     .then(() => {
-      return removeParentLinkIfNecessary();
+      return cleanupInstallAsDependency();
     })
     .then(() => {
       logIfInRoot(`\nminstall finished in ${systools.getRuntime(startTime)} :)\n\n`);

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -6,6 +6,7 @@ const os = require('os');
 const path = require('path');
 const Promise = require('bluebird');
 const readline = require('readline');
+const cwd = process.cwd();
 
 const UncriticalError = require('./UncriticalError.js');
 const systools = require('./systools.js');
@@ -14,7 +15,10 @@ const ModuleInfo = require('./ModuleInfo');
 
 let commandConcatSymbol = ';';
 let isInProjectRoot = true;
+
 let installedAsDependency = false;
+let dependencyInstallLinkedFolders = [];
+let projectFolderName = null;
 
 function logIfInRoot(message) {
   if (isInProjectRoot) {
@@ -24,7 +28,7 @@ function logIfInRoot(message) {
 
 function logVersionConflict(messages, moduleFolderName) {
 
-  const moduleFolder = path.join(process.cwd(), moduletools.modulesFolder, moduleFolderName);
+  const moduleFolder = path.join(cwd, moduletools.modulesFolder, moduleFolderName);
   console.log(`
 
 | UNCRITICAL DEPENDENCY-CONFLICTS FOUND:
@@ -43,11 +47,11 @@ function getInstalledModules() {
 }
 
 function checkStartConditions() {
-  return systools.verifyFolderName(process.cwd(), 'node_modules')
+  return systools.verifyFolderName(cwd, 'node_modules')
     .then((folderName) => {
       if (folderName == null) {
 
-        const pathParts = process.cwd().split(path.sep);
+        const pathParts = cwd.split(path.sep);
         if (pathParts[pathParts.length - 2] !== 'node_modules') {
           throw new UncriticalError('minstall started from outside the project-root. aborting.');
         } else {
@@ -55,7 +59,7 @@ function checkStartConditions() {
         }
       }
 
-      return systools.verifyFolderName(process.cwd(), moduletools.modulesFolder);
+      return systools.verifyFolderName(cwd, moduletools.modulesFolder);
     })
     .then((folderName) => {
       if (folderName == null) {
@@ -67,7 +71,7 @@ function checkStartConditions() {
       }
 
       return Promise.all([
-        systools.isSymlink(path.join(process.cwd(), 'node_modules')),
+        systools.isSymlink(path.join(cwd, 'node_modules')),
         getLocalPackageInfo(),
       ]);
     })
@@ -88,19 +92,19 @@ function checkStartConditions() {
 }
 
 function linkModuleToRoot(moduleFolder) {
-  const targetPath = path.join(process.cwd(), 'node_modules', moduleFolder);
-  const modulePath = path.join(process.cwd(), moduletools.modulesFolder, moduleFolder);
+  const targetPath = path.join(cwd, 'node_modules', moduleFolder);
+  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleFolder);
   return systools.link(modulePath, targetPath);
 }
 
 function linkRootToModule(moduleFolder) {
-  const rootModuleFolder = path.join(process.cwd(), 'node_modules');
-  const targetFolder = path.join(process.cwd(), moduletools.modulesFolder, moduleFolder, 'node_modules');
+  const rootModuleFolder = path.join(cwd, 'node_modules');
+  const targetFolder = path.join(cwd, moduletools.modulesFolder, moduleFolder, 'node_modules');
   return systools.link(rootModuleFolder, targetFolder);
 }
 
 function installMissingModuleDependencies(moduleFolder, missingDependencies) {
-  const moduleNodeModules = path.join(process.cwd(), moduletools.modulesFolder, moduleFolder, 'node_modules');
+  const moduleNodeModules = path.join(cwd, moduletools.modulesFolder, moduleFolder, 'node_modules');
   return systools.delete(moduleNodeModules)
     .then(() => {
       return moduletools.installPackets(missingDependencies);
@@ -112,7 +116,7 @@ function runPostinstall(moduleInfo) {
     return Promise.resolve();
   }
 
-  const modulePath = path.join(process.cwd(), moduletools.modulesFolder, moduleInfo.folderName);
+  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleInfo.folderName);
   return linkRootToModule(moduleInfo.folderName)
     .then(() => {
 
@@ -138,7 +142,7 @@ function cacheConflictingModules(conflictedDependencies, moduleFolderName) {
     return dependency.folderName;
   });
 
-  const rootNodeModules = path.join(process.cwd(), 'node_modules');
+  const rootNodeModules = path.join(cwd, 'node_modules');
   const cacheFolder = path.join(rootNodeModules, `${moduleFolderName}_cache`);
   return systools.moveMultiple(conflictedDependencyFolders, rootNodeModules, cacheFolder);
 }
@@ -153,9 +157,9 @@ function uncacheConflictingModules(conflictedDependencies, moduleFolderName) {
     return dependency.folderName;
   });
 
-  const rootNodeModules = path.join(process.cwd(), 'node_modules');
+  const rootNodeModules = path.join(cwd, 'node_modules');
   const cacheFolder = path.join(rootNodeModules, `${moduleFolderName}_cache`);
-  const moduleFolder = path.join(process.cwd(), moduletools.modulesFolder, moduleFolderName);
+  const moduleFolder = path.join(cwd, moduletools.modulesFolder, moduleFolderName);
   const moduleNodeModules = path.join(moduleFolder, 'node_modules');
 
   return systools.moveMultiple(conflictedDependencyFolders, rootNodeModules, moduleNodeModules)
@@ -175,8 +179,8 @@ function persistExistingConfilctingDependencies(packetsToKeep, moduleFolderName)
     return packet.folderName;
   });
 
-  const rootNodeModules = path.join(process.cwd(), 'node_modules');
-  const moduleNodeModules = path.join(process.cwd(), moduletools.modulesFolder, moduleFolderName, 'node_modules');
+  const rootNodeModules = path.join(cwd, 'node_modules');
+  const moduleNodeModules = path.join(cwd, moduletools.modulesFolder, moduleFolderName, 'node_modules');
   return systools.moveMultiple(packetFolderNames, moduleNodeModules, rootNodeModules);
 }
 
@@ -241,7 +245,18 @@ function prepareInstallAsDependency() {
     return Promise.resolve();
   }
 
-  return systools.link(path.join(process.cwd(), '..'), path.join(process.cwd(), 'node_modules'));
+  return systools.mkdir(path.join(cwd, 'node_modules'))
+    .then(() => {
+      return systools.getFolderNames(path.join(cwd, '..'));
+    })
+    .then((folderNames) => {
+      dependencyInstallLinkedFolders = folderNames;
+      dependencyInstallLinkedFolders.splice(dependencyInstallLinkedFolders.indexOf(projectFolderName), 1);
+
+      return Promise.all(dependencyInstallLinkedFolders.map((folderName) => {
+        systools.link(path.join(cwd, '..', folderName), path.join(cwd, 'node_modules', folderName))
+      }));
+    });
 }
 
 function cleanupInstallAsDependency() {
@@ -249,7 +264,16 @@ function cleanupInstallAsDependency() {
     return Promise.resolve();
   }
 
-  return systools.delete(path.join(process.cwd(), 'node_modules'));
+  return systools.deleteMultiple(dependencyInstallLinkedFolders, path.join(cwd, 'node_modules'))
+    .then(() => {
+      return systools.getFolderNames(path.join(cwd, 'node_modules'));
+    })
+    .then((folderNames) => {
+      return systools.moveMultiple(folderNames, path.join(cwd, 'node_modules'), path.join(cwd, '..'))
+    })
+    .then(() => {
+      return systools.delete(path.join(cwd, 'node_modules'));
+    });
 }
 
 function run() {
@@ -266,6 +290,9 @@ function run() {
     commandConcatSymbol = '&';
     moduletools.setNullTarget('NUL');
   }
+
+  const pathParts = cwd.split(path.sep);
+  projectFolderName = pathParts[pathParts.length - 1];
 
   let installedModules;
   let moduleInfos;
@@ -292,7 +319,7 @@ function run() {
       }
       logIfInRoot(`minstall found ${moduleInfos.length} local ${moduleText} in '${moduletools.modulesFolder}'`);
       return Promise.all(moduleInfos.map((moduleInfo) => {
-        return systools.delete(path.join(process.cwd(), 'node_modules', moduleInfo.folderName));
+        return systools.delete(path.join(cwd, 'node_modules', moduleInfo.folderName));
       }));
     })
     .then(() => {

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -14,6 +14,7 @@ const ModuleInfo = require('./ModuleInfo');
 
 let commandConcatSymbol = ';';
 let isInProjectRoot = true;
+let installedAsDependency = false;
 
 function logIfInRoot(message) {
   if (isInProjectRoot) {
@@ -45,7 +46,13 @@ function checkStartConditions() {
   return systools.verifyFolderName(process.cwd(), 'node_modules')
     .then((folderName) => {
       if (folderName == null) {
-        throw new UncriticalError('minstall started from outside the project-root. aborting.');
+
+        const pathParts = process.cwd().split(path.sep);
+        if (pathParts[pathParts.length - 2] !== 'node_modules') {
+          throw new UncriticalError('minstall started from outside the project-root. aborting.');
+        } else {
+          installedAsDependency = true;
+        }
       }
 
       return systools.verifyFolderName(process.cwd(), moduletools.modulesFolder);
@@ -55,12 +62,21 @@ function checkStartConditions() {
         throw new UncriticalError(`${moduletools.modulesFolder} not found, thus minstall is done :)`);
       }
 
+      if (installedAsDependency) {
+        return;
+      }
+
       return Promise.all([
         systools.isSymlink(path.join(process.cwd(), 'node_modules')),
         getLocalPackageInfo(),
       ]);
     })
     .then((results) => {
+
+      if (installedAsDependency) {
+        return;
+      }
+
       if (isInProjectRoot) {
         isInProjectRoot = !results[0];
       }
@@ -220,6 +236,22 @@ function installModules(installedModules, moduleInfos, index) {
     });
 }
 
+function linkFromParentIfNecessary() {
+  if (!installedAsDependency) {
+    return Promise.resolve();
+  }
+
+  return systools.link(path.join(process.cwd(), '..'), path.join(process.cwd(), 'node_modules'));
+}
+
+function removeParentLinkIfNecessary() {
+  if (!installedAsDependency) {
+    return Promise.resolve();
+  }
+
+  return systools.delete(path.join(process.cwd(), 'node_modules'));
+}
+
 function run() {
   const startTime = Date.now();
   if (process.argv[2] && process.argv[2] !== 'isChildProcess') {
@@ -238,6 +270,9 @@ function run() {
   let installedModules;
   let moduleInfos;
   checkStartConditions()
+    .then(() => {
+      return linkFromParentIfNecessary();
+    })
     .then(() => {
       return Promise.all([
         getInstalledModules(),
@@ -262,6 +297,9 @@ function run() {
     })
     .then(() => {
       return installModules(installedModules, moduleInfos);
+    })
+    .then(() => {
+      return removeParentLinkIfNecessary();
     })
     .then(() => {
       logIfInRoot(`\nminstall finished in ${systools.getRuntime(startTime)} :)\n\n`);

--- a/lib/systools.js
+++ b/lib/systools.js
@@ -45,6 +45,12 @@ const systools = {
     }));
   },
 
+  deleteMultiple(names, from) {
+    return Promise.all(names.map((name) => {
+      return this.delete(path.join(from, name));
+    }));
+  },
+
   link(modulePath, targetPath) {
     return new Promise((resolve, reject) => {
       fs.symlink(modulePath, targetPath, 'junction', (error) => {
@@ -56,9 +62,21 @@ const systools = {
     });
   },
 
+  mkdir(location) {
+    return new Promise((resolve, reject) => {
+      fs.mkdirs(location, (error) => {
+        if (error) {
+          return reject();
+        }
+
+        return resolve();
+      })
+    });
+  },
+
   runCommand(command) {
     return new Promise((resolve, reject) => {
-      exec(command, (error, stdout, stderr) => {
+      exec(command, {maxBuffer: 2097152}, (error, stdout, stderr) => {
         if (error !== null) {
           console.log('ERROR RUNNING COMMAND', command, error);
           return reject(error);


### PR DESCRIPTION
DO NOT MERGE UNTIL IT'S FINISHED!

Fixes #16

it can already detect if the project is installed as dependency, but the "providing of a proper node_modules"-part is not working yet. Everything is prepared though, as the setting up of this folder needs to be done in the `prepareInstallAsDependency`-method, and the cleanup needs to be done in the `cleanupInstallAsDependency`-method. Both are already called at the right times, but they don't do the right things yet