### PR TITLE
Feature/fix local modules as dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,20 +1,3 @@
-Skip to content
-This repository
-Search
-Pull requests
-Issues
-Gist
- @heikomat
- Unwatch 16
-  Star 0
- Fork 0 5minds/5minds.kaizen Private
- Code  Issues 50  Pull requests 0  Projects 1  Wiki  Pulse  Graphs
-Branch: develop Find file Copy path5minds.kaizen/backend/.editorconfig
-1a1bedf  on 8 Sep
-@heikomat heikomat Move main modules to parent-folder
-1 contributor
-RawBlameHistory
-17 lines (12 sloc)  258 Bytes
 # EditorConfig is awesome: http://EditorConfig.org
 
 root = true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "5minds"
+  "extends": "5minds",
+  "rules": {
+    "object-shorthand":"off"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# 1.4.0
+### Bugfixes
+- Fix installing a package as dependency with minstall-postinstall (see #16)
+
+# 1.3.7
+### Bugfixes
+- Fix already linked modules from a previous installation not being deleted before reinstall
+
+### Improvements
+- Add stdout-log to output when a command from within minstall fails
+
+# 1.3.6
+### Bugfixes
+- Fix installing of conflicting scoped dependencies
+
+# 1.3.3
+### Bugfixes
+- Fix wrong module-folder usage
+
+# 1.3.2
+### Improvements
+- Greatly improve logs. npm-warnings are now silenced (errors are still shown though)
+
+# 1.3.1
+### New Features
+- **minstall now installs conflicting dependencies correctly**, but gives a hint that the user might try to use non-conflicting package-versions
+- minstall now better detects, when it's started from the wrong folder, and exits without doing anything
+
+### Bugfixes
+- through the use of fs-extra instead of fs, the filesystem-operations are now easier and less prone to error
+
+### Improvements
+- Code cleanup
+
+# 1.2.0
+### Improvements
+- minstall will now throw an error and exit, if it detects incompatible versions of the same dependency
+- Code cleanup
+- use of the 5minds-eslint-styleguides instead of these from airbnb
+
+# 1.1.0
+### Improvements
+- Module-installation (especially for large projects) is now a lot faster
+- Running the script in a project-folder, that is already installed is now a lot faster
+- The whole code got refactored and cleaned up
+- Some logs are a little nicer
+
+# 1.0.8
+### New Features
+- added `modules-folder`-argument
+
+### Bugfixes
+- when verifying folder names, a non-existing folder is now considered unverified, instead of throwing an error
+
+### Improvements
+- Messages, for when there is nothing to do for minstall look like nice exit-messages now, instead of like errors

--- a/lib/ModuleInfo.js
+++ b/lib/ModuleInfo.js
@@ -8,6 +8,7 @@ class ModuleInfo {
 
   constructor(folderName, name, version, dependencies, postinstall) {
     this._folderName = folderName;
+    this._realFolderName = folderName;
     this._name = name;
     this._version = version;
     this._dependencies = dependencies;
@@ -18,8 +19,16 @@ class ModuleInfo {
     }
   }
 
+  // gets the folder-name the module should have according to it's module-name
   get folderName() {
     return this._folderName;
+  }
+
+  // get's the folder-name the module actually has on the disk.
+  // This should only differ from folderName for local modules,
+  // never for modules within node_modules
+  get realFolderName() {
+    return this._realFolderName;
   }
 
   get name() {

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -231,8 +231,8 @@ function installModules(installedModules, moduleInfos, index) {
       return uncacheConflictingModules(deps.conflicted, moduleInfo.realFolderName);
     })
     .then(() => {
-        // local modules should be linked using the folder-names they should have,
-        // no matter what folder-name they actually have, therefore don't use .realFolderName here
+      // local modules should be linked using the folder-names they should have,
+      // no matter what folder-name they actually have, therefore don't use .realFolderName here
       return linkModuleToRoot(moduleInfo);
     })
     .then(() => {

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -6,6 +6,7 @@ const os = require('os');
 const path = require('path');
 const Promise = require('bluebird');
 const readline = require('readline');
+
 const cwd = process.cwd();
 
 const UncriticalError = require('./UncriticalError.js');
@@ -206,7 +207,7 @@ function installModules(installedModules, moduleInfos, index) {
   }
 
   let packetsToKeep;
-  const deps = moduletools.getModuleDependencies(installedModules, moduleInfo);
+  const deps = moduletools.getModuleDependencies(installedModules, moduleInfos, moduleInfo);
   if (deps.messages.length > 0) {
     logVersionConflict(deps.messages, moduleInfo.folderName);
   }
@@ -254,7 +255,7 @@ function prepareInstallAsDependency() {
       dependencyInstallLinkedFolders.splice(dependencyInstallLinkedFolders.indexOf(projectFolderName), 1);
 
       return Promise.all(dependencyInstallLinkedFolders.map((folderName) => {
-        systools.link(path.join(cwd, '..', folderName), path.join(cwd, 'node_modules', folderName))
+        systools.link(path.join(cwd, '..', folderName), path.join(cwd, 'node_modules', folderName));
       }));
     });
 }
@@ -269,7 +270,7 @@ function cleanupInstallAsDependency() {
       return systools.getFolderNames(path.join(cwd, 'node_modules'));
     })
     .then((folderNames) => {
-      return systools.moveMultiple(folderNames, path.join(cwd, 'node_modules'), path.join(cwd, '..'))
+      return systools.moveMultiple(folderNames, path.join(cwd, 'node_modules'), path.join(cwd, '..'));
     })
     .then(() => {
       return systools.delete(path.join(cwd, 'node_modules'));

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -95,10 +95,15 @@ function checkStartConditions() {
     });
 }
 
-function linkModuleToRoot(moduleInfo) {
-  const targetPath = path.join(cwd, 'node_modules', moduleInfo.folderName);
-  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleInfo.realFolderName);
-  return systools.link(modulePath, targetPath);
+function linkModulesToRoot(moduleInfos) {
+  return Promise.all(moduleInfos.map((moduleInfo) => {
+
+    // local modules should be linked using the folder-names they should have,
+    // no matter what folder-name they actually have, therefore don't use .realFolderName here
+    const targetPath = path.join(cwd, 'node_modules', moduleInfo.folderName);
+    const modulePath = path.join(cwd, moduletools.modulesFolder, moduleInfo.realFolderName);
+    return systools.link(modulePath, targetPath);
+  }));
 }
 
 function linkRootToModule(moduleFolder) {
@@ -247,11 +252,6 @@ function installModules(installedModules, moduleInfos, index) {
       return uncacheConflictingModules(cachedModuleFolders, moduleInfo.realFolderName);
     })
     .then(() => {
-      // local modules should be linked using the folder-names they should have,
-      // no matter what folder-name they actually have, therefore don't use .realFolderName here
-      return linkModuleToRoot(moduleInfo);
-    })
-    .then(() => {
       return getInstalledModules();
     })
     .then((modules) => {
@@ -357,6 +357,9 @@ function run() {
     })
     .then(() => {
       return installModules(installedModules, moduleInfos);
+    })
+    .then(() => {
+      return this.linkModulesToRoot(moduleInfos);
     })
     .then(() => {
       return cleanupInstallAsDependency();

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -60,6 +60,9 @@ function checkStartConditions() {
         }
       }
 
+      if (moduletools.modulesFolder === '.') {
+        return Promise.resolve('.');
+      }
       return systools.verifyFolderName(cwd, moduletools.modulesFolder);
     })
     .then((folderName) => {
@@ -68,7 +71,7 @@ function checkStartConditions() {
       }
 
       if (installedAsDependency) {
-        return;
+        return null;
       }
 
       return Promise.all([

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -136,40 +136,51 @@ function runPostinstall(moduleInfo) {
     });
 }
 
-function cacheConflictingModules(conflictedDependencies, moduleFolderName) {
+function cacheConflictingModules(conflictedDependencies, notYetLinkedLocalModules, moduleFolderName) {
 
   if (conflictedDependencies.length === 0) {
-    return Promise.resolve();
+    return Promise.resolve([]);
   }
 
-  const conflictedDependencyFolders = conflictedDependencies.map((dependency) => {
+  const notYetLinkedLocalModuleNames = notYetLinkedLocalModules.map((module) => {
+    return module.name;
+  });
+
+  console.log('not yet linked local module names', notYetLinkedLocalModuleNames);
+  const cachedModuleFolders = conflictedDependencies.filter((module) => {
+    return notYetLinkedLocalModuleNames.indexOf(module.name) < 0;
+  })
+  .map((dependency) => {
     return dependency.folderName;
   });
+
+  if (cachedModuleFolders.length === 0) {
+    return Promise.resolve([]);
+  }
 
   const rootNodeModules = path.join(cwd, 'node_modules');
   const cacheFolder = path.join(rootNodeModules, `${moduleFolderName}_cache`);
-  return systools.moveMultiple(conflictedDependencyFolders, rootNodeModules, cacheFolder);
+  return systools.moveMultiple(cachedModuleFolders, rootNodeModules, cacheFolder)
+    .then(() => {
+      return cachedModuleFolders;
+    });
 }
 
-function uncacheConflictingModules(conflictedDependencies, moduleFolderName) {
+function uncacheConflictingModules(cachedModuleFolders, moduleFolderName) {
 
-  if (conflictedDependencies.length === 0) {
+  if (cachedModuleFolders.length === 0) {
     return Promise.resolve();
   }
-
-  const conflictedDependencyFolders = conflictedDependencies.map((dependency) => {
-    return dependency.folderName;
-  });
 
   const rootNodeModules = path.join(cwd, 'node_modules');
   const cacheFolder = path.join(rootNodeModules, `${moduleFolderName}_cache`);
   const moduleFolder = path.join(cwd, moduletools.modulesFolder, moduleFolderName);
   const moduleNodeModules = path.join(moduleFolder, 'node_modules');
 
-  return systools.moveMultiple(conflictedDependencyFolders, rootNodeModules, moduleNodeModules)
+  return systools.moveMultiple(cachedModuleFolders, rootNodeModules, moduleNodeModules)
     .then(() => {
 
-      return systools.moveMultiple(conflictedDependencyFolders, cacheFolder, rootNodeModules);
+      return systools.moveMultiple(cachedModuleFolders, cacheFolder, rootNodeModules);
     })
     .then(() => {
 
@@ -210,6 +221,7 @@ function installModules(installedModules, moduleInfos, index) {
   }
 
   let packetsToKeep;
+  let cachedModuleFolders;
   const deps = moduletools.getModuleDependencies(installedModules, moduleInfos, moduleInfo);
   if (deps.messages.length > 0) {
     logVersionConflict(deps.messages, moduleInfo.realFolderName);
@@ -219,9 +231,10 @@ function installModules(installedModules, moduleInfos, index) {
     .then((result) => {
       packetsToKeep = result.keep;
       deps.missing = result.missing;
-      return cacheConflictingModules(deps.conflicted, moduleInfo.realFolderName);
+      return cacheConflictingModules(deps.conflicted, moduleInfos.slice(index), moduleInfo.realFolderName);
     })
-    .then(() => {
+    .then((newlyCachedModuleFolders) => {
+      cachedModuleFolders = newlyCachedModuleFolders;
       return persistExistingConfilctingDependencies(packetsToKeep, moduleInfo.realFolderName);
     })
     .then(() => {
@@ -231,7 +244,7 @@ function installModules(installedModules, moduleInfos, index) {
       return runPostinstall(moduleInfo);
     })
     .then(() => {
-      return uncacheConflictingModules(deps.conflicted, moduleInfo.realFolderName);
+      return uncacheConflictingModules(cachedModuleFolders, moduleInfo.realFolderName);
     })
     .then(() => {
       // local modules should be linked using the folder-names they should have,

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -313,13 +313,13 @@ function run() {
       installedModules = modules[0];
       moduleInfos = modules[1];
       moduleInfos.sort((module1, module2) => {
-        console.log(Object.keys(module1.dependencies), module2.name);
-        if (Object.keys(module1.dependencies).indexOf(module2.name) >= 0)
-          {return 1;}
+        if (Object.keys(module1.dependencies).indexOf(module2.name) >= 0) {
+          return 1;
+        }
 
-        console.log(Object.keys(module2.dependencies), module1.name);
-        if (Object.keys(module2.dependencies).indexOf(module1.name) >= 0)
-          {return -1;}
+        if (Object.keys(module2.dependencies).indexOf(module1.name) >= 0) {
+          return -1;
+        }
 
         return 0;
       });

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -92,9 +92,9 @@ function checkStartConditions() {
     });
 }
 
-function linkModuleToRoot(moduleFolder) {
-  const targetPath = path.join(cwd, 'node_modules', moduleFolder);
-  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleFolder);
+function linkModuleToRoot(moduleInfo) {
+  const targetPath = path.join(cwd, 'node_modules', moduleInfo.folderName);
+  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleInfo.realFolderName);
   return systools.link(modulePath, targetPath);
 }
 
@@ -234,7 +234,7 @@ function installModules(installedModules, moduleInfos, index) {
     .then(() => {
         // local modules should be linked using the folder-names they should have,
         // no matter what folder-name they actually have, therefore don't use .realFolderName here
-      return linkModuleToRoot(moduleInfo.folderName);
+      return linkModuleToRoot(moduleInfo);
     })
     .then(() => {
       return getInstalledModules();

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -228,7 +228,6 @@ function installModules(installedModules, moduleInfos, index) {
       return runPostinstall(moduleInfo);
     })
     .then(() => {
-      console.log(moduleInfo);
       return uncacheConflictingModules(deps.conflicted, moduleInfo.realFolderName);
     })
     .then(() => {
@@ -313,6 +312,18 @@ function run() {
     .then((modules) => {
       installedModules = modules[0];
       moduleInfos = modules[1];
+      moduleInfos.sort((module1, module2) => {
+        console.log(Object.keys(module1.dependencies), module2.name);
+        if (Object.keys(module1.dependencies).indexOf(module2.name) >= 0)
+          {return 1;}
+
+        console.log(Object.keys(module2.dependencies), module1.name);
+        if (Object.keys(module2.dependencies).indexOf(module1.name) >= 0)
+          {return -1;}
+
+        return 0;
+      });
+
       if (moduleInfos.length === 0) {
         throw new UncriticalError('no modules found, thus minstall is done :)');
       }

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -236,7 +236,7 @@ function installModules(installedModules, moduleInfos, index) {
     .then((result) => {
       packetsToKeep = result.keep;
       deps.missing = result.missing;
-      return cacheConflictingModules(deps.conflicted, moduleInfos.slice(index), moduleInfo.realFolderName);
+      return cacheConflictingModules(deps.conflicted, moduleInfos, moduleInfo.realFolderName);
     })
     .then((newlyCachedModuleFolders) => {
       cachedModuleFolders = newlyCachedModuleFolders;
@@ -359,7 +359,7 @@ function run() {
       return installModules(installedModules, moduleInfos);
     })
     .then(() => {
-      return this.linkModulesToRoot(moduleInfos);
+      return linkModulesToRoot(moduleInfos);
     })
     .then(() => {
       return cleanupInstallAsDependency();

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -151,7 +151,6 @@ function cacheConflictingModules(conflictedDependencies, localModules, moduleFol
     return module.name;
   });
 
-  console.log('not yet linked local module names', notYetLinkedLocalModuleNames);
   // local modules are linked at the very end of the installation, thus all
   // local modules are "not yet linked"
   const cachedModuleFolders = conflictedDependencies.filter((module) => {

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -141,19 +141,21 @@ function runPostinstall(moduleInfo) {
     });
 }
 
-function cacheConflictingModules(conflictedDependencies, notYetLinkedLocalModules, moduleFolderName) {
+function cacheConflictingModules(conflictedDependencies, localModules, moduleFolderName) {
 
   if (conflictedDependencies.length === 0) {
     return Promise.resolve([]);
   }
 
-  const notYetLinkedLocalModuleNames = notYetLinkedLocalModules.map((module) => {
+  const localModuleNames = localModules.map((module) => {
     return module.name;
   });
 
   console.log('not yet linked local module names', notYetLinkedLocalModuleNames);
+  // local modules are linked at the very end of the installation, thus all
+  // local modules are "not yet linked"
   const cachedModuleFolders = conflictedDependencies.filter((module) => {
-    return notYetLinkedLocalModuleNames.indexOf(module.name) < 0;
+    return localModuleNames.indexOf(module.name) < 0;
   })
   .map((dependency) => {
     return dependency.folderName;
@@ -171,18 +173,27 @@ function cacheConflictingModules(conflictedDependencies, notYetLinkedLocalModule
     });
 }
 
-function uncacheConflictingModules(cachedModuleFolders, moduleFolderName) {
+function uncacheConflictingModules(cachedModuleFolders, conflictingModules, moduleFolderName) {
 
-  if (cachedModuleFolders.length === 0) {
+  if (cachedModuleFolders.length === 0 && conflictingModules.length === 0) {
     return Promise.resolve();
   }
+
+  const conflictingModuleFolders = conflictingModules.map((module) => {
+    // the conflicting packet was installed into the folderName that it's module-name
+    // requires it to have, thus don't use the realFolderName from the conflicting module
+    // as this might be a local name, that is not the same
+    return module.folderName;
+  });
 
   const rootNodeModules = path.join(cwd, 'node_modules');
   const cacheFolder = path.join(rootNodeModules, `${moduleFolderName}_cache`);
   const moduleFolder = path.join(cwd, moduletools.modulesFolder, moduleFolderName);
   const moduleNodeModules = path.join(moduleFolder, 'node_modules');
 
-  return systools.moveMultiple(cachedModuleFolders, rootNodeModules, moduleNodeModules)
+  // because of possible local modules, the conflicting modules and the actually cached modules don't have to be the same
+  // move all modules that caused conflicts to the module-node_modules, but only uncache the modules that actually got cached
+  return systools.moveMultiple(conflictingModuleFolders, rootNodeModules, moduleNodeModules)
     .then(() => {
 
       return systools.moveMultiple(cachedModuleFolders, cacheFolder, rootNodeModules);
@@ -249,7 +260,7 @@ function installModules(installedModules, moduleInfos, index) {
       return runPostinstall(moduleInfo);
     })
     .then(() => {
-      return uncacheConflictingModules(cachedModuleFolders, moduleInfo.realFolderName);
+      return uncacheConflictingModules(cachedModuleFolders, deps.conflicted, moduleInfo.realFolderName);
     })
     .then(() => {
       return getInstalledModules();

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -117,8 +117,8 @@ function runPostinstall(moduleInfo) {
     return Promise.resolve();
   }
 
-  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleInfo.folderName);
-  return linkRootToModule(moduleInfo.folderName)
+  const modulePath = path.join(cwd, moduletools.modulesFolder, moduleInfo.realFolderName);
+  return linkRootToModule(moduleInfo.realFolderName)
     .then(() => {
 
       let command = moduleInfo.postinstall;
@@ -203,34 +203,37 @@ function installModules(installedModules, moduleInfos, index) {
     if (moduleInfos.length > 9 && moduleNumber <= 9) {
       moduleNumber = `0${moduleNumber}`;
     }
-    process.stdout.write(`installing module ${moduleNumber}/${moduleInfos.length} -> ${moduleInfo.folderName} `);
+    process.stdout.write(`installing module ${moduleNumber}/${moduleInfos.length} -> ${moduleInfo.realFolderName} `);
   }
 
   let packetsToKeep;
   const deps = moduletools.getModuleDependencies(installedModules, moduleInfos, moduleInfo);
   if (deps.messages.length > 0) {
-    logVersionConflict(deps.messages, moduleInfo.folderName);
+    logVersionConflict(deps.messages, moduleInfo.realFolderName);
   }
 
-  return moduletools.getPreinstalledPacketsEvaluation(moduleInfo.folderName, deps.missing)
+  return moduletools.getPreinstalledPacketsEvaluation(moduleInfo.realFolderName, deps.missing)
     .then((result) => {
       packetsToKeep = result.keep;
       deps.missing = result.missing;
-      return cacheConflictingModules(deps.conflicted, moduleInfo.folderName);
+      return cacheConflictingModules(deps.conflicted, moduleInfo.realFolderName);
     })
     .then(() => {
-      return persistExistingConfilctingDependencies(packetsToKeep, moduleInfo.folderName);
+      return persistExistingConfilctingDependencies(packetsToKeep, moduleInfo.realFolderName);
     })
     .then(() => {
-      return installMissingModuleDependencies(moduleInfo.folderName, deps.missing);
+      return installMissingModuleDependencies(moduleInfo.realFolderName, deps.missing);
     })
     .then(() => {
       return runPostinstall(moduleInfo);
     })
     .then(() => {
-      return uncacheConflictingModules(deps.conflicted, moduleInfo.folderName);
+      console.log(moduleInfo);
+      return uncacheConflictingModules(deps.conflicted, moduleInfo.realFolderName);
     })
     .then(() => {
+        // local modules should be linked using the folder-names they should have,
+        // no matter what folder-name they actually have, therefore don't use .realFolderName here
       return linkModuleToRoot(moduleInfo.folderName);
     })
     .then(() => {
@@ -320,6 +323,8 @@ function run() {
       }
       logIfInRoot(`minstall found ${moduleInfos.length} local ${moduleText} in '${moduletools.modulesFolder}'`);
       return Promise.all(moduleInfos.map((moduleInfo) => {
+        // local modules should be linked using the folder-names they should have,
+        // no matter what folder-name they actually have, therefore don't use .realFolderName here
         return systools.delete(path.join(cwd, 'node_modules', moduleInfo.folderName));
       }));
     })

--- a/lib/moduletools.js
+++ b/lib/moduletools.js
@@ -82,10 +82,9 @@ const moduletools = {
     const conflictDependencies = [];
     const messages = [];
     const avaliablePackets = installedPackets.concat(localPackets);
-    const avaliablePacketNames = avaliablePackets.concat(localPackets)
-      .map((module) => {
-        return module.name;
-      });
+    const avaliablePacketNames = avaliablePackets.map((module) => {
+      return module.name;
+    });
 
     let avaliableIndex = -1;
     let checkVersion = null;

--- a/lib/moduletools.js
+++ b/lib/moduletools.js
@@ -14,7 +14,7 @@ const moduletools = {
   setModulesFolder(modulesFolder) {
     this.modulesFolder = modulesFolder;
   },
-  
+
   setNullTarget(nullTarget) {
     this.nullTarget = nullTarget;
   },
@@ -31,8 +31,8 @@ const moduletools = {
       .then((folderNames) => {
         scopedFolder = folderNames.filter((folderName) => {
           return folderName.indexOf('@') === 0;
-        })
-        
+        });
+
         return Promise.all(folderNames.map((folderName) => {
           return this.verifyModule(modulesPath, folderName);
         }));
@@ -77,26 +77,28 @@ const moduletools = {
     return moduleNames.join('\n');
   },
 
-  getModuleDependencies(installedPackets, moduleInfo) {
+  getModuleDependencies(installedPackets, localPackets, moduleInfo) {
     const missingDependencies = [];
     const conflictDependencies = [];
     const messages = [];
-    const installedPacketNames = installedPackets.map((module) => {
-      return module.name;
-    });
+    const avaliablePackets = installedPackets.concat(localPackets);
+    const avaliablePacketNames = avaliablePackets.concat(localPackets)
+      .map((module) => {
+        return module.name;
+      });
 
-    let installedIndex = -1;
+    let avaliableIndex = -1;
     let checkVersion = null;
     let targetRange = null;
 
-    for (let name in moduleInfo.dependencies) {
-      installedIndex = installedPacketNames.indexOf(name);
+    for (const name in moduleInfo.dependencies) {
+      avaliableIndex = avaliablePacketNames.indexOf(name);
       targetRange = moduleInfo.dependencies[name];
 
-      if (installedIndex >= 0) {
-        checkVersion = installedPackets[installedIndex].version;
+      if (avaliableIndex >= 0) {
+        checkVersion = avaliablePackets[avaliableIndex].version;
         if (!semver.satisfies(checkVersion, targetRange)) {
-          conflictDependencies.push(installedPackets[installedIndex]);
+          conflictDependencies.push(avaliablePackets[avaliableIndex]);
           missingDependencies.push({name: name, version: moduleInfo.dependencies[name]});
           messages.push(`${name} ${checkVersion} is installed, but ${moduleInfo.name} wants ${targetRange}`);
         }

--- a/lib/systools.js
+++ b/lib/systools.js
@@ -40,7 +40,7 @@ const systools = {
   moveMultiple(names, from, to) {
     return Promise.all(names.map((name) => {
       return this.move(path.join(from, name), path.join(to, name), {
-        clobber: true,
+        overwrite: true,
       });
     }));
   },
@@ -53,7 +53,7 @@ const systools = {
 
   link(modulePath, targetPath) {
     return new Promise((resolve, reject) => {
-      fs.symlink(modulePath, targetPath, 'junction', (error) => {
+      fs.ensureSymlink(modulePath, targetPath, 'junction', (error) => {
 
         // even if the link-command failed (e.g. when the link already exists),
         // the script should continue, thus there is no reject

--- a/lib/systools.js
+++ b/lib/systools.js
@@ -70,7 +70,7 @@ const systools = {
         }
 
         return resolve();
-      })
+      });
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "1.5.0-pre",
+  "version": "1.5.0-pre2",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "1.5.0-pre3",
+  "version": "1.5.0-pre4",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "1.5.0-pre4",
+  "version": "1.5.0-pre14",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "1.5.0-pre2",
+  "version": "1.5.0-pre3",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "1.5.0-pre14",
+  "version": "1.5.0",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "1.4.1",
+  "version": "1.5.0-pre",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "fs-extra": "^1.0.0",
+    "fs-extra": "^2.0.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Improve some code-style
- Fix handling of scoped local modules
- Link scoped local-modules to the scoped folder where they belong, even if they are not in the scoped folder inside of modules
- update fs-extras-dependency to ^2.0.0
- Fixes #17 
- Add Support for `.` as module-folder, if you just want to install a bunch of modules that are in a folder, and that don't have a "parent-project"