### PR TITLE
 fix no-save-install

### DIFF
--- a/lib/moduletools.js
+++ b/lib/moduletools.js
@@ -196,7 +196,7 @@ const moduletools = {
       nullTarget = '';
     }
 
-    return systools.runCommand(`npm install --loglevel ${npmiLoglevel} ${identities.join(' ')}${nullTarget}`)
+    return systools.runCommand(`npm install --no-save --loglevel ${npmiLoglevel} ${identities.join(' ')}${nullTarget}`)
       .catch((error) => {
 
         // This error might just be a warning from npm-install


### PR DESCRIPTION
as of npm 5, an npm install will automatically update the dependencies in a package.json. Because minstall shouldn't touch the package.json files, i add the `--no-save` flag by default with this change