### PR TITLE
🐛 fix target folder name of linked modules

### DIFF
--- a/lib/ModuleInfo.js
+++ b/lib/ModuleInfo.js
@@ -16,7 +16,8 @@ class ModuleInfo {
     this._isScoped = false;
 
     if (name.charAt(0) === '@') {
-      this._folderName = path.join(name.split('/')[0], name.split('/')[1]);
+      const moduleNameParts = name.split('/');
+      this._folderName = path.join(moduleNameParts[0], moduleNameParts[1]);
       this._isScoped = true;
     }
   }

--- a/lib/ModuleInfo.js
+++ b/lib/ModuleInfo.js
@@ -7,8 +7,8 @@ const Promise = require('bluebird');
 class ModuleInfo {
 
   constructor(folderName, name, version, dependencies, postinstall) {
-    this._folderName = folderName;
     this._realFolderName = folderName;
+    this._folderName = name;
     this._name = name;
     this._version = version;
     this._dependencies = dependencies;
@@ -16,7 +16,7 @@ class ModuleInfo {
     this._isScoped = false;
 
     if (name.charAt(0) === '@') {
-      this._folderName = path.join(name.split('/')[0], folderName);
+      this._folderName = path.join(name.split('/')[0], name.split('/')[1]);
       this._isScoped = true;
     }
   }


### PR DESCRIPTION
When linking the local modules to the node_modules folder, minstall does so using the folder-names that the module is supposed to have according to its name.

until now, minstall used the modules actual folder name as target folder name. This PR changes that.

You can test this as follows:
create a local module with foldername `testmoduleA`, and give it the name `testmoduleB`. When using minstall, the module will then be linked to `nodule_modules/testmoduleA`, even though it should be `node_modules/testmoduleB`.