### PR TITLE
Feature/trust locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugfixes
 - Fixes a bug where in rare cases minstall was wrongfully printing error-messages about installed packages not being found
 - Added a workaround to work around https://github.com/snyamathi/semver-intersect/issues/7
+- If an error occurs during installation, then minstall will now actually fail with exit-code 1
 
 # 3.1.0
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Added a workaround to work around https://github.com/snyamathi/semver-intersect/issues/7
 - If an error occurs during installation, then minstall will now actually fail with exit-code 1
 
+### Improvements
+minstall will now exit without doing anything when it detects that you're using
+npm 5.7.0. That version of npm has a very serious bug, see https://github.com/npm/npm/issues/19883
+
 # 3.1.0
 ### New Features
 - new `--link-only`-flag (makes minstall fix all linked dependencies (including links to local modules))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   module satisfies every requested version of that module that is not valid
   semver (like github-urls and tag-names)
 
+### Bugfixes
+- Added a workaround to work around https://github.com/snyamathi/semver-intersect/issues/7
+
 # 3.1.0
 ### New Features
 - new `--link-only`-flag (makes minstall fix all linked dependencies (including links to local modules))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.2.0
+### New Features
+- new Flag `--assume-local-modules-satisfy-non-semver-dependency-versions` (aka
+  `--trust-local-modules`). Setting this makes minstall assume that a local
+  module satisfies every requested version of that module that is not valid
+  semver (like github-urls and tag-names)
+
 # 3.1.0
 ### New Features
 - new `--link-only`-flag (makes minstall fix all linked dependencies (including links to local modules))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   semver (like github-urls and tag-names)
 
 ### Bugfixes
+- Fixes a bug where in rare cases minstall was wrongfully printing error-messages about installed packages not being found
 - Added a workaround to work around https://github.com/snyamathi/semver-intersect/issues/7
 
 # 3.1.0

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Minstall knows the following flags:
 - `--link-only` makes minstall go through the linking-process only, without installing anything
 - `--clean` makes minstall remove all node_modules-folders before installing dependencies (this is forced for npm5)
 - `--dependency-check-only` makes install print the dependency-check only, without touching any files or installing anything
+- `--assume-local-modules-satisfy-non-semver-dependency-versions` (aka `--trust-local-modules`) makes minstall assume that a local module satisfies every requested version of that module that is not valid semver (like github-urls and tag-names)
+- `--dependency-check-only` makes install print the dependency-check only, without touching any files or installing anything
 - `--loglevel <loglevel>` sets the loglevel (`error`, `warn`, `info` `verbose`, `debug`, `silly`)
 
 ## In collaboration with

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -57,8 +57,16 @@ function checkStartConditions() {
       localPackage = results[1];
       npmVersion = results[2];
 
-      // npm 5 workaround until npm-issue #16853 is fixed
+      if (semver.satisfies(npmVersion, '5.7.0')) {
+        logger.error(`You're using npm 5.7.0. Do not use this version, it has a critical bug that is fixed in 5.7.1. See npm-issue #19883 for more info`);
+        process.exit(1);
+      }
+
+      // npm 5 workaround until npm-issue #16853 is fixed replace the if-confition
+      // and log when npm >= 5.7.1 is confirmed working without that workaround
+      // if (semver.satisfies(npmVersion, '>=5.0.0 <5.7.0')) {
       if (semver.major(npmVersion) === 5) {
+        //logger.info('npm >=5.0.0 <5.7.0 detected. forcing --cleanup');
         logger.info('npm 5 detected. forcing --cleanup');
         cleanup = true;
       }

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -624,7 +624,7 @@ function fixMissingDependenciesWithSymlinks() {
               continue;
             }
 
-            if (installedModule.location === path.join(module.fullModulePath, 'node_modules')) {
+            if (installedModule.fullModulePath === path.join(module.fullModulePath, 'node_modules', installedModule.folderName)) {
               fittingInstalledModule = installedModule;
               dependencyAlreadyInstalled = true;
               break;
@@ -787,7 +787,7 @@ function parseProcessArguments() {
       cleanup = true;
     } else if (process.argv[i] === '--dependency-check-only') {
       dependencyCheckOnly = true;
-    } else if (process.argv[i] === '--assume-local-modules-satisfy-non-semver-dependency-versions' || '--trust-local-modules') {
+    } else if (process.argv[i] === '--assume-local-modules-satisfy-non-semver-dependency-versions' || process.argv[i] === '--trust-local-modules') {
       assumeLocalModulesSatisfyNonSemverDependencyVersions = true;
     } else if (process.argv[i] === '--link-only') {
       linkOnly = true;

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -253,7 +253,7 @@ function removeAlreadySatisfiedDependencies(requestedDependencies, localModules,
           continue;
         }
 
-        const shortenedLocalLocation = localModule.location.substr(cwd.length);
+        const shortenedLocalLocation = `.${localModule.location.substr(cwd.length)}`;
         const shortenedRequesterLocations = result[requestedDependencyName][requestedDependencyVersionRange].map((locationOfRequestingModule) => {
           return `.${locationOfRequestingModule.substr(cwd.length)}`;
         });

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -255,7 +255,7 @@ function removeAlreadySatisfiedDependencies(requestedDependencies, localModules,
 
         const shortenedLocalLocation = localModule.location.substr(cwd.length);
         const shortenedRequesterLocations = result[requestedDependencyName][requestedDependencyVersionRange].map((locationOfRequestingModule) => {
-          return locationOfRequestingModule.substr(cwd.length);
+          return `.${locationOfRequestingModule.substr(cwd.length)}`;
         });
 
         if (rangeIsInvalidAndAssumedToBeSatisfied) {
@@ -266,7 +266,7 @@ function removeAlreadySatisfiedDependencies(requestedDependencies, localModules,
         for (const locationOfRequestingModule of result[requestedDependencyName][requestedDependencyVersionRange]) {
           // if the version matches the local module will satisfy the dependency, because even if it would get shadowed,
           // shadowed dependencies will get fixed with symlinks!
-          const shortenedRequesterLocation = locationOfRequestingModule.substr(cwd.length);
+          const shortenedRequesterLocation = `.${locationOfRequestingModule.substr(cwd.length)}`;
           logger.debug(`dependency ${requestedDependencyName}@${requestedDependencyVersionRange} requested by '${shortenedRequesterLocation}' will be satisfied by local version ${localModule.version} in '${path.join(shortenedLocalLocation)}'`);
         }
         delete result[requestedDependencyName][requestedDependencyVersionRange];

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -166,7 +166,12 @@ function findRequestedDependencies(localModules) {
       for (const version in requestedDependencies[dependency]) {
         let intersection = null;
         try {
-          intersection = intersect(requestedVersion, version);
+          // this condition is a workaround for https://github.com/snyamathi/semver-intersect/issues/7
+          if (version < requestedVersion) {
+            intersection = intersect(version, requestedVersion);
+          } else {
+            intersection = intersect(requestedVersion, version);
+          }
         } catch (error) {
           // the versions didn't intersect. That's ok!
         }

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -166,12 +166,7 @@ function findRequestedDependencies(localModules) {
       for (const version in requestedDependencies[dependency]) {
         let intersection = null;
         try {
-          // this condition is a workaround for https://github.com/snyamathi/semver-intersect/issues/7
-          if (version < requestedVersion) {
-            intersection = intersect(version, requestedVersion);
-          } else {
-            intersection = intersect(requestedVersion, version);
-          }
+          intersection = intersect(version, requestedVersion);
         } catch (error) {
           // the versions didn't intersect. That's ok!
         }

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -29,6 +29,7 @@ let npmVersion = null;
 let cleanup = false;
 let dependencyCheckOnly = false;
 let linkOnly = false;
+let assumeLocalModulesSatisfyNonSemverDependencyVersions = false;
 
 function logVerbose() {
   return ['verbose', 'debug', 'silly'].indexOf(logger.level) >= 0;
@@ -49,7 +50,7 @@ function checkStartConditions() {
   return Promise.all([
     systools.verifyFolderName(cwd, 'node_modules'),
     getLocalPackageInfo(),
-    systools.runCommand('npm --version'),
+    systools.runCommand('npm --version', true),
   ])
     .then((results) => {
       const folderName = results[0];
@@ -244,15 +245,28 @@ function removeAlreadySatisfiedDependencies(requestedDependencies, localModules,
           continue;
         }
 
-        if (!semver.satisfies(localModule.version, requestedDependencyVersionRange)) {
+        const rangeIsValidAndSatisfied = semver.validRange(requestedDependencyVersionRange) && semver.satisfies(localModule.version, requestedDependencyVersionRange);
+        const rangeIsInvalidAndAssumedToBeSatisfied = !semver.validRange(requestedDependencyVersionRange) && assumeLocalModulesSatisfyNonSemverDependencyVersions;
+        const dependencyIsSatisfiedByLocalModule = rangeIsValidAndSatisfied || rangeIsInvalidAndAssumedToBeSatisfied;
+
+        if (!dependencyIsSatisfiedByLocalModule) {
           continue;
+        }
+
+        const shortenedLocalLocation = localModule.location.substr(cwd.length);
+        const shortenedRequesterLocations = result[requestedDependencyName][requestedDependencyVersionRange].map((locationOfRequestingModule) => {
+          return locationOfRequestingModule.substr(cwd.length);
+        });
+
+        if (rangeIsInvalidAndAssumedToBeSatisfied) {
+
+          logger.info(`Assuming that local module ${shortenedLocalLocation} satisfies ${requestedDependencyName}@${requestedDependencyVersionRange} requested by ${shortenedRequesterLocations.join(', ')}`);
         }
 
         for (const locationOfRequestingModule of result[requestedDependencyName][requestedDependencyVersionRange]) {
           // if the version matches the local module will satisfy the dependency, because even if it would get shadowed,
           // shadowed dependencies will get fixed with symlinks!
           const shortenedRequesterLocation = locationOfRequestingModule.substr(cwd.length);
-          const shortenedLocalLocation = localModule.location.substr(cwd.length);
           logger.debug(`dependency ${requestedDependencyName}@${requestedDependencyVersionRange} requested by '${shortenedRequesterLocation}' will be satisfied by local version ${localModule.version} in '${path.join(shortenedLocalLocation)}'`);
         }
         delete result[requestedDependencyName][requestedDependencyVersionRange];
@@ -455,7 +469,27 @@ function printNonOptimalLocalModuleUsage(localModules, requestedDependencies) {
 
     // find the most requested version
     const requestedWithIncompatibleVersion = requestedDependencyArray.filter((dependency) => {
-      return dependency.name === localVersionOfDependency.name && !semver.satisfies(localVersionOfDependency.version, dependency.versionRange);
+      // if the name doesn't match then this is not a dependency we're looking for
+      if (dependency.name !== localVersionOfDependency.name) {
+        return false;
+      }
+
+      // if the local version satisfies the requested range, then this dependency is not incompatible
+      if (semver.satisfies(localVersionOfDependency.version, dependency.versionRange)) {
+        return false;
+      }
+
+      // At this point, the only at way for the dependency to be not incompatible,
+      // is if the requested versionrange is not a valid semver range, and the
+      // flag to assume that these are fulfilled is set
+      if (assumeLocalModulesSatisfyNonSemverDependencyVersions === true && !semver.validRange(dependency.versionRange)) {
+        return false;
+      }
+
+      // at this point we either have a valid but non-satisfied semver-range, or
+      // an invalid semver-range while not assuming that local modules satisfy
+      // these invalid ranges
+      return true;
     });
 
     // if no conflicting version is requested, continue
@@ -581,6 +615,7 @@ function fixMissingDependenciesWithSymlinks() {
 
       for (const module of localModules) {
         for (const dependency in module.dependencies) {
+          const requestedDependencyVersionRange = module.dependencies[dependency];
           // check if the dependency is already installed localy
           let dependencyAlreadyInstalled = false;
           let fittingInstalledModule = null;
@@ -593,7 +628,7 @@ function fixMissingDependenciesWithSymlinks() {
               fittingInstalledModule = installedModule;
               dependencyAlreadyInstalled = true;
               break;
-            } else if (semver.satisfies(installedModule.version, module.dependencies[dependency])) {
+            } else if (semver.satisfies(installedModule.version, requestedDependencyVersionRange)) {
               fittingInstalledModule = installedModule;
             }
           }
@@ -605,8 +640,12 @@ function fixMissingDependenciesWithSymlinks() {
           // in short, the order is: direct install > local module > indirect install
           if ((!fittingInstalledModule || !dependencyAlreadyInstalled) && linkModules) {
             for (const localModule of localModules) {
-              if (localModule.name !== dependency ||
-                !semver.satisfies(localModule.version, module.dependencies[dependency])) {
+
+              const rangeIsValidAndSatisfied = semver.validRange(requestedDependencyVersionRange) && semver.satisfies(localModule.version, requestedDependencyVersionRange);
+              const rangeIsInvalidAndAssumedToBeSatisfied = !semver.validRange(requestedDependencyVersionRange) && assumeLocalModulesSatisfyNonSemverDependencyVersions;
+              const dependencyIsSatisfiedByLocalModule = rangeIsValidAndSatisfied || rangeIsInvalidAndAssumedToBeSatisfied;
+
+              if (localModule.name !== dependency || !dependencyIsSatisfiedByLocalModule) {
                 continue;
               }
 
@@ -748,6 +787,8 @@ function parseProcessArguments() {
       cleanup = true;
     } else if (process.argv[i] === '--dependency-check-only') {
       dependencyCheckOnly = true;
+    } else if (process.argv[i] === '--assume-local-modules-satisfy-non-semver-dependency-versions' || '--trust-local-modules') {
+      assumeLocalModulesSatisfyNonSemverDependencyVersions = true;
     } else if (process.argv[i] === '--link-only') {
       linkOnly = true;
     }

--- a/lib/minstall.js
+++ b/lib/minstall.js
@@ -312,7 +312,7 @@ function determineDependencyTargetFolder(requestedDependencyArray, alreadyInstal
         return `.${requestedByPath.substr(cwd.length)}`;
       }).join('\n  ');
 
-      logger.warn(`${requestedDependency.requestedBy.length} modules request ${requestedDependency.identifier}. This dependency won't get optimized (hoisted), Because '${requestedDependency.versionRange}' is not a vaild semver-range. These modules all get their own copy of that Dependency:\n  ${requestedByString}`);
+      logger.warn(`${requestedDependency.requestedBy.length} modules request ${requestedDependency.identifier}. This dependency won't get optimized (hoisted), because '${requestedDependency.versionRange}' is not a vaild semver-range. If ${requestedDependency.name} is one of your local modules, you can try the --trust-loca-modules flag. These modules all get their own copy of that Dependency:\n  ${requestedByString}`);
       for (const installationTarget of requestedDependency.requestedBy) {
 
         if (!optimalDependencyTargetFolder[installationTarget]) {

--- a/lib/moduletools.js
+++ b/lib/moduletools.js
@@ -170,7 +170,17 @@ const moduletools = {
     return systools.runCommand(`cd ${targetFolder}${this.commandConcatSymbol} npm install --no-save --no-package-lock --loglevel ${npmiLoglevel} ${identifier.join(' ')}${nullTarget}`)
       .catch((error) => {
 
-        // This error might just be a warning from npm-install
+        // npm pushes all its info- and wanr-logs to stderr. If we have a debug
+        // flag set, and we wouldn't catch here, then minstall would fail
+        // although the installation was successful.
+        // npm however only exits with an error-code if actual errors happened.
+        // because of this, minstall should fail if an errorcode > 0 exists
+        if (error.code !== undefined && error.code !== null && error.code > 0) {
+          throw error;
+        }
+
+        // If no error-code exists, then this is just info-stuff that npm pushes
+        // to stderr, so we reroute it to stdout instead of throwing an error
         process.stdout.write(error.message);
       });
   },

--- a/lib/moduletools.js
+++ b/lib/moduletools.js
@@ -176,7 +176,7 @@ const moduletools = {
         // npm however only exits with an error-code if actual errors happened.
         // because of this, minstall should fail if an errorcode > 0 exists
         if (error.code !== undefined && error.code !== null && error.code > 0) {
-          throw error;
+          process.exit(1);
         }
 
         // If no error-code exists, then this is just info-stuff that npm pushes

--- a/lib/systools.js
+++ b/lib/systools.js
@@ -48,7 +48,7 @@ const systools = {
     });
   },
 
-  runCommand(command) {
+  runCommand(command, silent = false) {
     logger.verbose('running command', command);
     return new Promise((resolve, reject) => {
       exec(command, {maxBuffer: 2097152}, (error, stdout, stderr) => {
@@ -66,7 +66,7 @@ const systools = {
           return reject(new Error(`\nA command from within minstall produced a warning or an error:\ncommand: ${command}\nlog-output:\n${stdout}\n\nmessage:\n${stderr}\n`));
         }
 
-        if (stdout.length > 0) {
+        if (stdout.length > 0 && !silent) {
           process.stdout.write(`\n${stdout}`);
         }
         return resolve(stdout);

--- a/lib/systools.js
+++ b/lib/systools.js
@@ -48,7 +48,11 @@ const systools = {
     });
   },
 
-  runCommand(command, silent = false) {
+  runCommand(command, silent) {
+    if (silent == undefined || silent == null) {
+      silent = false;
+    }
+
     logger.verbose('running command', command);
     return new Promise((resolve, reject) => {
       exec(command, {maxBuffer: 2097152}, (error, stdout, stderr) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "3.2.0-pre3",
+  "version": "3.2.0-pre5",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "3.2.0-pre1",
+  "version": "3.2.0-pre2",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "3.2.0-pre5",
+  "version": "3.2.0-pre6",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "3.1.0",
+  "version": "3.2.0-pre1",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "3.2.0-pre6",
+  "version": "3.2.0-pre7",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minstall",
-  "version": "3.2.0-pre2",
+  "version": "3.2.0-pre3",
   "description": "local module installer",
   "main": "lib/minstall.js",
   "bin": "lib/minstall.js",
@@ -36,7 +36,7 @@
     "bluebird": "^3.4.6",
     "fs-extra": "^2.1.2",
     "semver": "^5.3.0",
-    "semver-intersect": "^1.3.0",
+    "semver-intersect": "^1.3.1",
     "winston": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### New Features
- new Flag `--assume-local-modules-satisfy-non-semver-dependency-versions` (aka
  `--trust-local-modules`). Setting this makes minstall assume that a local
  module satisfies every requested version of that module that is not valid
  semver (like github-urls and tag-names)

A use case is as follows:

- You have modules A, B and C.
- A requires B and C as dependency.
- You develop a new feature that requires changes in B and C.
- You `npm publish` B and C with an npm-tag
- In A, you set that npm-tag as dependency-version for B and C

When you now run minstall with `--trust-local-modules`, then B and C will be linked into A/node_modules, even though minstall can't tell if the versions in the package.jsons of B and C satisfy whatever is behind the tag-dependencies set in A. Minstall just trusts that B and C will fit, if the dependencies in A aren't valid semver. Without that flag, minstall installs the published version directly into A/node_modules, instead of linking the local ones (again because the dependencies in A aren't valid semver)

### Bugfixes
- Fixes a bug where in rare cases minstall was wrongfully printing error-messages about installed packages not being found
- Added a workaround to work around https://github.com/snyamathi/semver-intersect/issues/7